### PR TITLE
fix: consent information status code

### DIFF
--- a/PoingGodotAdMob/src/ads/PoingGodotAdMobConsentInformation.mm
+++ b/PoingGodotAdMob/src/ads/PoingGodotAdMobConsentInformation.mm
@@ -41,7 +41,19 @@ PoingGodotAdMobConsentInformation *PoingGodotAdMobConsentInformation::get_single
 };
 
 int PoingGodotAdMobConsentInformation::get_consent_status() {
-    return static_cast<int>([UMPConsentInformation.sharedInstance consentStatus]);
+    UMPConsentStatus status = [UMPConsentInformation.sharedInstance consentStatus];
+    switch (status) {
+        case UMPConsentStatusUnknown:
+            return 0;
+        case UMPConsentStatusNotRequired:
+            return 1;
+        case UMPConsentStatusRequired:
+            return 2;
+        case UMPConsentStatusObtained:
+            return 3;
+        default:
+            return 0;
+    }
 }
 
 bool PoingGodotAdMobConsentInformation::get_is_consent_form_available() {


### PR DESCRIPTION
iOS UMPConsentStatus status = [UMPConsentInformation.sharedInstance consentStatus]; ENUM differs from the android version which creates an issue when checking for consent status and resulting in form not being shown on iOS in some cases.

More specifically, on [IOS]:(https://developers.google.com/admob/android/privacy/api/reference/com/google/android/ump/ConsentInformation.ConsentStatus)

`
UMPConsentStatusUnknown = 0
UMPConsentStatusRequired = 1
UMPConsentStatusNotRequired = 2
UMPConsentStatusObtained = 3
`

while on [Android](https://developers.google.com/admob/ios/privacy/api/reference/Enums/UMPConsentStatus)

`
UNKNOWN = 0
NOT_REQUIRED = 1
REQUIRED = 2
OBTAINED = 3
`

We could either fix this here or do a fix in the admob gdscript side of things, but I believe this would be cleaner. 